### PR TITLE
[links] adding vector crypto part2 links + cleanup

### DIFF
--- a/lib/exto.js
+++ b/lib/exto.js
@@ -96,12 +96,12 @@ const exto = {
 
   // Vector Crypto
   zvkned:   {desc: 'Vector NIST Cipher AES encryption and decryption', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
-  zvknha:   {desc: 'Vector NIST SHA-256 Secure Hash', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
-  zvknhb:   {desc: 'Vector NIST SHA-256 and SHA-512 Secure Hash', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
-  zvkb:     {desc: 'Vector Crypto Bitmanip', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
-  zvksh:    {desc: 'Vector Shang-Mi 3 Hash function (SM3)', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
+  zvknha:   {desc: 'Vector NIST SHA-256 Secure Hash', url: fproxSubstack + 'risc-v-vector-cryptography-extension'},
+  zvknhb:   {desc: 'Vector NIST SHA-256 and SHA-512 Secure Hash', url: fproxSubstack + 'risc-v-vector-cryptography-extension'},
+  zvkb:     {desc: 'Vector Crypto Bitmanip', url: fproxSubstack + 'risc-v-vector-cryptography-extension'},
+  zvksh:    {desc: 'Vector Shang-Mi 3 Hash function (SM3)', url: fproxSubstack + 'risc-v-vector-cryptography-extension'},
   zvksed:   {desc: 'Vector Shang-Mi 4 Cipher (SM4) encryption and decryption', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
-  zvkg:     {desc: 'Vector GCM/GMAC', url: fproxSubstack + 'risc-v-vector-cryptography-extensions'},
+  zvkg:     {desc: 'Vector GCM/GMAC', url: fproxSubstack + 'risc-v-vector-cryptography-extension'},
 
   zvl32b:   {desc: 'Minimum Vector Length = 32',    url: vSpec + 'v-spec.adoc#zvl-minimum-vector-length-standard-extensions'},
   zvl64b:   {desc: 'Minimum Vector Length = 64',    url: vSpec + 'v-spec.adoc#zvl-minimum-vector-length-standard-extensions'},
@@ -110,7 +110,7 @@ const exto = {
   zvl512b:  {desc: 'Minimum Vector Length = 512',   url: vSpec + 'v-spec.adoc#zvl-minimum-vector-length-standard-extensions'},
   zvl1024b: {desc: 'Minimum Vector Length = 1024',  url: vSpec + 'v-spec.adoc#zvl-minimum-vector-length-standard-extensions'},
 
-  zvlsseg:  {desc: '[DEPRICATED] Vector segment load/stores supported'},
+  zvlsseg:  {desc: '[DEPRECATED] Vector segment load/stores supported'},
 
   zvamo:    {desc: 'Vector AMO', url: vSpec + 'v-amo.adoc'},
 
@@ -120,7 +120,7 @@ const exto = {
   zfinx:    {ver: 1, desc: 'Standard Extension for single-precision Floating-Point in Integer Registers'},
   zdinx:    {ver: 1, desc: 'Standard Extension for double-precision Floating-Point in Integer Registers'},
   zhinx:    {ver: 1, desc: 'Standard Extension for half-precision Floating-Point in Integer Registers'},
-  zhinxmin: {ver: 1, desc: 'Standard Extension for half-precision Floating-Point in Integer Registers'},
+  zhinxmin: {ver: 1, desc: 'Standard Extension for half-precision Floating-Point in Integer Registers (Minimal Subset)'},
 
   zfa:      {ver: 0.1, desc: 'Standard Extension for Additional Floating-Point Instructions'}, // Ch.25
 


### PR DESCRIPTION
Switching some links for vector crypto extension fo fprox's article part 2 + some cleanup